### PR TITLE
feat(cell validation): add comprehensive data validation capabilities

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -337,3 +337,23 @@ validate_excel_range(
 - `start_cell`: Starting cell of range
 - `end_cell`: Optional ending cell of range
 - Returns: Validation result message
+
+### get_data_validation_info
+
+Get data validation rules and metadata for a worksheet.
+
+```python
+get_data_validation_info(filepath: str, sheet_name: str) -> str
+```
+
+- `filepath`: Path to Excel file
+- `sheet_name`: Target worksheet name
+- Returns: JSON string containing all data validation rules with metadata including:
+  - Validation type (list, whole, decimal, date, time, textLength)
+  - Operator (between, notBetween, equal, greaterThan, lessThan, etc.)
+  - Allowed values for list validations (resolved from ranges)
+  - Formula constraints for numeric/date validations
+  - Cell ranges where validation applies
+  - Prompt and error messages
+
+**Note**: The `read_data_from_excel` tool automatically includes validation metadata for individual cells when available.

--- a/src/excel_mcp/cell_validation.py
+++ b/src/excel_mcp/cell_validation.py
@@ -1,0 +1,179 @@
+import logging
+from typing import Any, Dict, List, Optional
+
+from openpyxl.worksheet.worksheet import Worksheet
+from openpyxl.utils.cell import coordinate_from_string, column_index_from_string
+
+logger = logging.getLogger(__name__)
+
+def get_data_validation_for_cell(worksheet: Worksheet, cell_address: str) -> Optional[Dict[str, Any]]:
+    """Get data validation metadata for a specific cell.
+    
+    Args:
+        worksheet: The openpyxl worksheet object
+        cell_address: Cell address like 'A1', 'B2', etc.
+        
+    Returns:
+        Dictionary with validation metadata or None if no validation exists
+    """
+    try:
+        # Convert cell address to row/col coordinates
+        col_letter, row = coordinate_from_string(cell_address)
+        col_idx = column_index_from_string(col_letter)
+        
+        # Check each data validation rule in the worksheet
+        for dv in worksheet.data_validations.dataValidation:
+            # Check if this cell is covered by the validation rule
+            if _cell_in_validation_range(row, col_idx, dv):
+                return _extract_validation_metadata(dv, cell_address, worksheet)
+                
+        return None
+        
+    except Exception as e:
+        logger.warning(f"Failed to get validation for cell {cell_address}: {e}")
+        return None
+
+def _cell_in_validation_range(row: int, col: int, data_validation) -> bool:
+    """Check if a cell is within a data validation range."""
+    try:
+        # data_validation.sqref contains the cell ranges this validation applies to
+        for cell_range in data_validation.sqref.ranges:
+            if (cell_range.min_row <= row <= cell_range.max_row and 
+                cell_range.min_col <= col <= cell_range.max_col):
+                return True
+        return False
+    except Exception as e:
+        logger.warning(f"Error checking if cell ({row}, {col}) is in validation range for DV sqref '{getattr(data_validation, 'sqref', 'N/A')}': {e}")
+        return False
+
+def _extract_validation_metadata(data_validation, cell_address: str, worksheet: Optional[Worksheet] = None) -> Dict[str, Any]:
+    """Extract metadata from a DataValidation object."""
+    try:
+        validation_info = {
+            "cell": cell_address,
+            "has_validation": True,
+            "validation_type": data_validation.type,
+            "allow_blank": data_validation.allowBlank,
+        }
+        
+        # Add operator for validation types that use it
+        if data_validation.operator:
+            validation_info["operator"] = data_validation.operator
+        
+        # Add optional fields if they exist
+        if data_validation.prompt:
+            validation_info["prompt"] = data_validation.prompt
+        if data_validation.promptTitle:
+            validation_info["prompt_title"] = data_validation.promptTitle
+        if data_validation.error:
+            validation_info["error_message"] = data_validation.error
+        if data_validation.errorTitle:
+            validation_info["error_title"] = data_validation.errorTitle
+            
+        # For list type validations (dropdown lists), extract allowed values
+        if data_validation.type == "list" and data_validation.formula1:
+            allowed_values = _extract_list_values(data_validation.formula1, worksheet)
+            validation_info["allowed_values"] = allowed_values
+            
+        # For other validation types, include the formulas
+        elif data_validation.formula1:
+            validation_info["formula1"] = data_validation.formula1
+            if data_validation.formula2:
+                validation_info["formula2"] = data_validation.formula2
+                
+        return validation_info
+        
+    except Exception as e:
+        logger.warning(f"Failed to extract validation metadata: {e}")
+        return {
+            "cell": cell_address,
+            "has_validation": True,
+            "validation_type": "unknown",
+            "error": f"Failed to parse validation: {e}"
+        }
+
+def _extract_list_values(formula: str, worksheet: Optional[Worksheet] = None) -> List[str]:
+    """Extract allowed values from a list validation formula."""
+    try:
+        # Remove quotes if present
+        formula = formula.strip('"')
+        
+        # Handle comma-separated list
+        if ',' in formula:
+            # Split by comma and clean up each value
+            values = [val.strip().strip('"') for val in formula.split(',')]
+            return [val for val in values if val]  # Remove empty values
+            
+        # Handle range reference (e.g., "$A$1:$A$5" or "Sheet1!$A$1:$A$5")
+        elif (':' in formula or formula.startswith('$')) and worksheet:
+            try:
+                # Remove potential leading '=' if it's a formula like '=Sheet1!$A$1:$A$5'
+                range_ref = formula
+                if formula.startswith('='):
+                    range_ref = formula[1:]
+                
+                actual_values = []
+                # worksheet[range_ref] can resolve ranges like "A1:A5" or "SheetName!A1:A5"
+                # It returns a tuple of tuples of cells for ranges, or a single cell
+                range_cells = worksheet[range_ref]
+                
+                # Handle single cell or range
+                if hasattr(range_cells, 'value'):  # Single cell
+                    if range_cells.value is not None:
+                        actual_values.append(str(range_cells.value))
+                else:  # Range of cells
+                    for row_of_cells in range_cells:
+                        # Handle case where row_of_cells might be a single cell
+                        if hasattr(row_of_cells, 'value'):
+                            if row_of_cells.value is not None:
+                                actual_values.append(str(row_of_cells.value))
+                        else:
+                            for cell in row_of_cells:
+                                if cell.value is not None:
+                                    actual_values.append(str(cell.value))
+                
+                if actual_values:
+                    return actual_values
+                return [f"Range: {formula} (empty or unresolvable)"]
+                
+            except Exception as e:
+                logger.warning(f"Could not resolve range '{formula}' for list validation: {e}")
+                return [f"Range: {formula} (resolution error)"]
+                
+        # Handle range reference when worksheet not available
+        elif ':' in formula or formula.startswith('$'):
+            return [f"Range: {formula}"]
+            
+        # Single value
+        else:
+            return [formula.strip('"')]
+            
+    except Exception as e:
+        logger.warning(f"Failed to parse list formula '{formula}': {e}")
+        return [formula]  # Return original formula if parsing fails
+
+def get_all_validation_ranges(worksheet: Worksheet) -> List[Dict[str, Any]]:
+    """Get all data validation ranges in a worksheet.
+    
+    Returns:
+        List of dictionaries containing validation range information
+    """
+    validations = []
+    
+    try:
+        for dv in worksheet.data_validations.dataValidation:
+            validation_info = {
+                "ranges": str(dv.sqref),
+                "validation_type": dv.type,
+                "allow_blank": dv.allowBlank,
+            }
+            
+            if dv.type == "list" and dv.formula1:
+                validation_info["allowed_values"] = _extract_list_values(dv.formula1, worksheet)
+                
+            validations.append(validation_info)
+            
+    except Exception as e:
+        logger.warning(f"Failed to get validation ranges: {e}")
+        
+    return validations 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.10"
 
 [[package]]
@@ -67,17 +66,19 @@ wheels = [
 
 [[package]]
 name = "excel-mcp-server"
-version = "0.1.1"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "openpyxl" },
+    { name = "typer" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", extras = ["cli"], specifier = ">=1.2.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
     { name = "openpyxl", specifier = ">=3.1.2" },
+    { name = "typer", specifier = ">=0.15.1" },
 ]
 
 [[package]]
@@ -158,7 +159,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.2.1"
+version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -166,13 +167,14 @@ dependencies = [
     { name = "httpx-sse" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "sse-starlette" },
     { name = "starlette" },
-    { name = "uvicorn" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/30/51e4555826126e3954fa2ab1e934bf74163c5fe05e98f38ca4d0f8abbf63/mcp-1.2.1.tar.gz", hash = "sha256:c9d43dbfe943aa1530e2be8f54b73af3ebfb071243827b4483d421684806cb45", size = 103968 }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/bc/54aec2c334698cc575ca3b3481eed627125fb66544152fa1af927b1a495c/mcp-1.9.1.tar.gz", hash = "sha256:19879cd6dde3d763297617242888c2f695a95dfa854386a6a68676a646ce75e4", size = 316247 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/0d/6770742a84c8aa1d36c0d628896a380584c5759612e66af7446af07d8775/mcp-1.2.1-py3-none-any.whl", hash = "sha256:579bf9c9157850ebb1344f3ca6f7a3021b0123c44c9f089ef577a7062522f0fd", size = 66453 },
+    { url = "https://files.pythonhosted.org/packages/a6/c0/4ac795585a22a0a2d09cd2b1187b0252d2afcdebd01e10a68bbac4d34890/mcp-1.9.1-py3-none-any.whl", hash = "sha256:2900ded8ffafc3c8a7bfcfe8bc5204037e988e753ec398f371663e6a06ecd9a9", size = 130261 },
 ]
 
 [package.optional-dependencies]
@@ -320,6 +322,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add cell_validation.py module for Excel data validation metadata extraction
- Implement get_data_validation_for_cell() and get_all_validation_ranges()
- Include validation metadata in read_data_from_excel responses automatically
- Add get_data_validation_info MCP tool for validation rule summaries
- Resolve range references in list validations to actual cell values
- Support all validation types: list, whole, decimal, date, time, textLength
- Include operators (between, notBetween, equal, greaterThan, etc.) in metadata

This allows LLMs to understand Excel validation constraints including dropdown options, numeric ranges, date constraints, and text length limits.