### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
   <img src="assets/logo.png" alt="Excel MCP Server Logo" width="300"/>
 </p>
 
+<a href="https://glama.ai/mcp/servers/@haris-musa/excel-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@haris-musa/excel-mcp-server/badge" alt="excel-mcp-server MCP server" />
+</a>
+
 [![PyPI version](https://img.shields.io/pypi/v/excel-mcp-server.svg)](https://pypi.org/project/excel-mcp-server/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/excel-mcp-server.svg)](https://pypi.org/project/excel-mcp-server/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
This PR adds a badge for the [excel-mcp-server](https://glama.ai/mcp/servers/@haris-musa/excel-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@haris-musa/excel-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@haris-musa/excel-mcp-server/badge" alt="excel-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.