### PR TITLE
Fix FastMCP compatibility issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "mcp[cli]>=1.10.1",
+    "fastmcp>=2.0.0,<3.0.0",
     "openpyxl>=3.1.5",
     "typer>=0.16.0"
 ]

--- a/src/excel_mcp/server.py
+++ b/src/excel_mcp/server.py
@@ -66,16 +66,7 @@ logger = logging.getLogger("excel-mcp")
 # Initialize FastMCP server
 mcp = FastMCP(
     "excel-mcp",
-    version="0.1.5",
-    description="Excel MCP Server for manipulating Excel files",
-    dependencies=["openpyxl>=3.1.5"],
-    env_vars={
-        "EXCEL_FILES_PATH": {
-            "description": "Path to Excel files directory",
-            "required": False,
-            "default": EXCEL_FILES_PATH
-        }
-    }
+    instructions="Excel MCP Server for manipulating Excel files"
 )
 
 def get_excel_path(filename: str) -> str:


### PR DESCRIPTION
## Summary

Users updating their environments (e.g., running `pip install --upgrade` or reinstalling) suddenly find excel-mcp-server broken with a TypeError. This PR fixes the FastMCP 2.x compatibility issue and adds version constraints to prevent future breaking changes.

## Root Cause Analysis

The excel-mcp-server uses [FastMCP](https://github.com/jlowin/fastmcp), a Python framework for building MCP (Model Context Protocol) servers. The excel-mcp-server was configured with an **unbounded version constraint** for its dependencies. The `pyproject.toml` only specified `mcp[cli]>=1.10.1` without any upper bound, which allowed any newer version to be installed, including versions with breaking API changes.

When FastMCP released version 2.0 ([compare v1.0...v2.0.0](https://github.com/jlowin/fastmcp/compare/v1.0...v2.0.0)), it introduced breaking changes to the API. The FastMCP constructor was changed in [`src/fastmcp/server/server.py`](https://github.com/jlowin/fastmcp/compare/v1.0...v2.0.0#diff-8c8969dac5f7e6b7c0a1e5f0a6c8f1f5):

**v1.0:** The constructor accepted various parameters through `**settings`
**v2.0:** The constructor now explicitly requires `name` and `instructions` parameters, while the old parameters (`version`, `description`, `dependencies`, `env_vars`) are no longer supported

This caused the following error for users:
```
TypeError: FastMCP.__init__() got an unexpected keyword argument 'version'
```

## Solution

This PR implements a two-part fix:

### 1. Code Changes
Updated the FastMCP initialization to use only the currently supported parameters:
- Removed unsupported parameters: `version`, `dependencies`, `env_vars`
- Changed `description` parameter to `instructions`
- Kept minimal initialization that works with FastMCP 2.x API

### 2. Dependency Constraints
Added explicit version constraints to prevent future breaking changes:
- Added `fastmcp>=2.0.0,<3.0.0` to dependencies
- This ensures compatibility with FastMCP 2.x while preventing automatic updates to FastMCP 3.x

## Testing

Tested locally with FastMCP 2.10.6 and confirmed the server starts successfully without errors.

Fixes #76